### PR TITLE
support for arbitrary params in Verify::call()

### DIFF
--- a/telesign/api.class.php
+++ b/telesign/api.class.php
@@ -284,8 +284,7 @@ class Verify extends Telesign {
 	 * 
 	 * @return string The fully formed response object repersentation of the JSON reply
 	 */
-	public function call($phone_number, $verify_code = "", $language = "", $verify_method = "", $extension_type = "", $extension_template = "", $redial = "") {
-		$more = array();
+	public function call($phone_number, $verify_code = "", $language = "", $verify_method = "", $extension_type = "", $extension_template = "", $redial = "", $more = array()) {
 		if (!empty($language)) {
 			$more['language'] = $language;
 		}


### PR DESCRIPTION
This would allow us to pass in arbitrary params that are not explicitly supported by the call() method, such as the new "pressx" param.

I would recommend a similar change to any other methods that have additional params available beyond what the method header contains.
