### PR TITLE
Fix Non-psr4 naming for Config class #26

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace telesign\sdk;
+
 use Composer\InstalledVersions;
 
 class Config {


### PR DESCRIPTION
Rename filename from config.php to Config.php and add new line between namespace and use